### PR TITLE
Implement writing on monolith

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,12 +63,16 @@ const INSPECTIONS = {
     touch: ["feel"],
 };
 
+const INTERACTIONS = {
+    write: ["paint", "draw"],
+}
+
 const DEATH_DESCRIPTION = `<div>You are overcome. Darkness descends and your breathing stops.</div>
 
 <div>Return to the place of honor as a new investigator?<br />("restart")</div>`;
 
-function canonicalizeSense(verb) {
-    for (const [canon, aliases] of Object.entries(INSPECTIONS)) {
+function canonicalizeVerb(verb, type = INSPECTIONS) {
+    for (const [canon, aliases] of Object.entries(type)) {
         if (verb === canon || aliases.includes(verb)) {
             return canon;
         }
@@ -381,12 +385,14 @@ ${Object.keys(DEFAULT_ROOM_SENSES)
         } else {
             // i.e. player is alive
             // const restArray = tokenizedAction.slice(1);
-            const perceptionVerb = canonicalizeSense(verb);
+            const perceptionVerb = canonicalizeVerb(verb, INSPECTIONS);
+            const interactionVerb = canonicalizeVerb(verb, INTERACTIONS);
             if (MOVE_VERBS.includes(verb)) {
                 this.lastError = this.movePlayer(restString);
             } else if (perceptionVerb) {
                 this.lastError = await this.inspect(perceptionVerb, restString);
-            } else if (verb === "write") {
+            } else if (interactionVerb) {
+                // TODO (when adding new interactions): refactor for more interaction types
                 this.lastError = this.attemptWrite(restString);
             } else if (verb && restString) {
                 // Unknown verb, but there's also an object.
@@ -528,7 +534,7 @@ You conclude <q>${hidden}</q> means <q>${unhidden}</q>.
         }
         currentRoomWriteableItem.rosetta = `${currentRoomWriteableItem.rosetta || ""} ${text}`.trim();
         currentRoomWriteableItem.writtenWords = `${currentRoomWriteableItem.writtenWords || ""} ${text}`.trim();
-        this.currentDescription = this.currentRoom().senses.write;
+        this.currentDescription = currentRoomWriteableItem.write;
         return "";
     }
 

--- a/music.js
+++ b/music.js
@@ -76,6 +76,9 @@ export default class Music {
         });
 
         this.melodysequence = new Tone.Part((time, note) => {
+            melodySynth.set({
+                detune: gaussianRandom() * this.detune
+            });
             melodySynth.triggerAttackRelease(note, 0.25, time);
         }, melodyPart);
 

--- a/world.js
+++ b/world.js
@@ -88,7 +88,10 @@ export const PERMANENT = {
             location: "home",
             sense: {
                 see: "The leader addresses you, asking a question, and gesture to the carved tablet they hold.",
-                hear: "The leader asks you to go west to the place of honor, and bring back its power to your community."
+                hear: 
+`The leader asks you to go west to the place of honor, and bring back its power to your community.
+The leader motions to the jar of paint strapped to your belt and tells you to mark your knowledge so
+ others may learn of the place's honor and power.` 
             }
         },
         leader_tablet: {
@@ -112,13 +115,13 @@ export const PERMANENT = {
                 see: "A gray stone monolith, twice your height, with writing engraved into it. Some of the writing has been worn away.",
                 touch: "The monolith is cold and smooth.",
                 taste: "Stony and mineral-like.",
-                write: "You carefully paint to help your community understand the strange symbols found in this place."
+                write: "You carefully paint on the monolith to help your community understand the strange symbols found in this place."
             },
             location: "outside",
             passive: {
                 see: "a gray stone monolith",
             },
-            rosetta: ""
+            rosetta: "",
         },
         info_text_1: {
             aliases: ["first panel", "panels", "panel", "writing", "damaged panel", "altered panel"],

--- a/world.js
+++ b/world.js
@@ -112,11 +112,13 @@ export const PERMANENT = {
                 see: "A gray stone monolith, twice your height, with writing engraved into it. Some of the writing has been worn away.",
                 touch: "The monolith is cold and smooth.",
                 taste: "Stony and mineral-like.",
+                write: "You carefully paint to help your community understand the strange symbols found in this place."
             },
             location: "outside",
             passive: {
                 see: "a gray stone monolith",
             },
+            rosetta: ""
         },
         info_text_1: {
             aliases: ["first panel", "panels", "panel", "writing", "damaged panel", "altered panel"],
@@ -229,7 +231,7 @@ export const PERMANENT = {
             ]
         },
         "hot cell light": {
-            aliases: ["light", "ceiling", "whine"],
+            aliases: ["light", "ceiling", "whine", "globe"],
             moveable: false,
             location: "nowhere",
             passive: {
@@ -268,6 +270,7 @@ export const PERMANENT = {
             senses: {},
             droneVolume: -13,
             lightLevel: 1,
+            writeableItem: "monolith1",
         },
         "information center": {
             exits: {


### PR DESCRIPTION
Implements writing just for the monolith outside.

As implemented each room can have one writeable item and that is stored on the room object. I think a `writeable` prop on each item would be better for a number of reasons, but implementing `write {item} {word}` and its possible variations instead of `write {word}` is a bit much to get done today.